### PR TITLE
fix: add worklet directive to gesture callbacks to fix Reanimated 3 warnings

### DIFF
--- a/src/components/PiPViewImpl.tsx
+++ b/src/components/PiPViewImpl.tsx
@@ -101,6 +101,7 @@ export const PiPViewImpl = ({ children }: PropsWithChildren) => {
         .runOnJS(true)
         .shouldCancelWhenOutside(true)
         .onTouchesUp(() => {
+          // This runs on JS thread due to .runOnJS(true)
           if (dockSide.value) {
             return;
           }

--- a/src/hooks/usePanGesture.ts
+++ b/src/hooks/usePanGesture.ts
@@ -205,6 +205,7 @@ export const usePanGesture = (): {
   const pan = useMemo(() => {
     return Gesture.Pan()
       .onStart(() => {
+        'worklet';
         if (disabled) {
           return;
         }
@@ -213,6 +214,7 @@ export const usePanGesture = (): {
         isPanActive.set(true);
       })
       .onUpdate((e) => {
+        'worklet';
         if (disabled) {
           return;
         }
@@ -245,6 +247,7 @@ export const usePanGesture = (): {
         translationX.set(newTranslationX);
       })
       .onEnd((event) => {
+        'worklet';
         if (disabled) {
           return;
         }

--- a/src/hooks/usePinchGesture.ts
+++ b/src/hooks/usePinchGesture.ts
@@ -20,14 +20,17 @@ export const usePinchGesture = ({
     () =>
       Gesture.Pinch()
         .onStart(() => {
+          'worklet';
           pinchScaleOffset.value = scale.value;
         })
         .onUpdate((event) => {
+          'worklet';
           const pinchDelta = (event.scale - 1) * SCALE_RESISTANCE_FACTOR;
           const value = pinchScaleOffset.value * (1 + pinchDelta);
           scale.value = clamp(value, 0.5, 1.5);
         })
         .onEnd(() => {
+          'worklet';
           let target = 1;
           if (scale.value < 0.85) {
             target = 0.7;


### PR DESCRIPTION
## Summary

This PR fixes a warning that appears when using this library with react-native-gesture-handler and Reanimated 3:

```
[WARN] [react-native-gesture-handler] None of the callbacks in the gesture are worklets. 
If you wish to run them on the JS thread use '.runOnJS(true)' modifier on the gesture to make this explicit. 
Otherwise, mark the callbacks as 'worklet' to run them on the UI thread.
```

## Changes

- Added `'worklet'` directive to all pan gesture callbacks (onStart, onUpdate, onEnd) in `usePanGesture.ts`
- Added `'worklet'` directive to all pinch gesture callbacks (onStart, onUpdate, onEnd) in `usePinchGesture.ts`
- Added clarifying comment for tap gesture that already uses `.runOnJS(true)`

## Impact

This is a non-breaking change that ensures compatibility with the latest versions of Reanimated and react-native-gesture-handler.