### PR TITLE
Fix typo: horizontalOffet → horizontalOffset

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export default function App() {
         height: height - 80,
         y: 100,
         x: 0,
-        horizontalOffet: 12,
+        horizontalOffset: 12,
       }}
     >
       <View style={{ width: 120, height: 80, backgroundColor: 'gray' }} />
@@ -105,7 +105,7 @@ interface DestroyArea {
 ### 📐 `ScreenLayoutDimensions`
 
 > ⚠️ **Important:** If you enable `snapToEdges`, make sure the `layout.width` matches the full screen width. This ensures the PiP view can properly align with screen edges.
-> You can also use the optional `horizontalOffet` prop to add padding between the PiP view and the screen edge after snapping. This helps prevent the PiP from being flush against the edge.
+> You can also use the optional `horizontalOffset` prop to add padding between the PiP view and the screen edge after snapping. This helps prevent the PiP from being flush against the edge.
 
 ```ts
 interface ScreenLayoutDimensions {
@@ -113,7 +113,7 @@ interface ScreenLayoutDimensions {
   y: number;
   width: number;
   height: number;
-  horizontalOffet?: number;
+  horizontalOffset?: number;
 }
 ```
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -31,7 +31,7 @@ export default function App() {
             height: height - 80,
             y: 100,
             x: 0,
-            horizontalOffet: 12,
+            horizontalOffset: 12,
           }}
           edgeHandle={{
             left: <View style={styles.handle} />,

--- a/src/components/PiPViewImpl.tsx
+++ b/src/components/PiPViewImpl.tsx
@@ -116,11 +116,11 @@ export const PiPViewImpl = ({ children }: PropsWithChildren) => {
   );
 
   const handleExpandView = useCallback(() => {
-    const minX = layout.horizontalOffet ?? 0;
+    const minX = layout.horizontalOffset ?? 0;
     const maxX =
       layout.width -
       scaledElementLayout.value.width -
-      (layout.horizontalOffet ?? 0);
+      (layout.horizontalOffset ?? 0);
 
     const targetX = dockSide.value === 'left' ? minX : maxX;
     translationX.value = targetX;
@@ -131,7 +131,7 @@ export const PiPViewImpl = ({ children }: PropsWithChildren) => {
     overDragSide.value = null;
     dockSide.value = null;
   }, [
-    layout.horizontalOffet,
+    layout.horizontalOffset,
     layout.width,
     scaledElementLayout.value.width,
     dockSide,

--- a/src/hooks/useInitialPosition.ts
+++ b/src/hooks/useInitialPosition.ts
@@ -35,7 +35,7 @@ export const useInitialPosition = ({
       'worklet';
       if (isNumberValue(position)) {
         const positionWithinContainer =
-          position + (layout.x || 0) + (layout.horizontalOffet ?? 0);
+          position + (layout.x || 0) + (layout.horizontalOffset ?? 0);
         return positionWithinContainer;
       }
 
@@ -54,7 +54,7 @@ export const useInitialPosition = ({
           return 0;
       }
     },
-    [edges.value, layout.horizontalOffet, layout.x]
+    [edges.value, layout.horizontalOffset, layout.x]
   );
 
   const resolveYPosition = useCallback(

--- a/src/hooks/usePanGesture.ts
+++ b/src/hooks/usePanGesture.ts
@@ -74,14 +74,14 @@ export const usePanGesture = (): {
     () =>
       edges.value.minX -
       scaledElementLayout.value.width -
-      (layout.horizontalOffet ?? 0) * 1
+      (layout.horizontalOffset ?? 0) * 1
   );
 
   const hiddenRightXValue = useDerivedValue(
     () =>
       edges.value.maxX +
       scaledElementLayout.value.width +
-      (layout.horizontalOffet ?? 0) * 1
+      (layout.horizontalOffset ?? 0) * 1
   );
 
   const handlePanEnd = useCallback(

--- a/src/models.ts
+++ b/src/models.ts
@@ -32,7 +32,7 @@ export type DestroyArea = {
 };
 
 export type ScreenLayoutDimensions = ContainerLayoutRectangle & {
-  horizontalOffet?: number;
+  horizontalOffset?: number;
 };
 
 export interface PiPViewProps {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,16 +11,16 @@ export const getEdges = (
   return {
     minY: currentContainerLayout.y ?? 0,
     minX:
-      (currentContainerLayout.horizontalOffet ?? 0) +
+      (currentContainerLayout.horizontalOffset ?? 0) +
       (currentContainerLayout.x ?? 0),
 
     maxX:
       currentContainerLayout.width -
       currentScaledElementLayout.value.width -
-      (currentContainerLayout.horizontalOffet ?? 0),
+      (currentContainerLayout.horizontalOffset ?? 0),
     maxY:
       currentContainerLayout.height -
       currentScaledElementLayout.value.height -
-      (currentContainerLayout.horizontalOffet ?? 0),
+      (currentContainerLayout.horizontalOffset ?? 0),
   };
 };


### PR DESCRIPTION
Fixes a typo in the ScreenLayoutDimensions API: horizontalOffet → horizontalOffset.