### PR TITLE
Refactor: modernize gestures, animations and internals; adopt React Compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ export default function App() {
 | `onPress`         | `() => void`                                   | Callback triggered on PiP tap.                                                     |
 | `edgeHandle`      | `{ left: ReactElement; right: ReactElement; }` | Customizable left and right handles that appear when the PiP is hidden off-screen. |
 
+> 💡 **Tip:** Object props (`layout`, `destroyArea`, `initialPosition`, `edgeHandle`) and callbacks (`onPress`, `onDestroy`) should be memoized (`useMemo` / `useCallback`) in the consuming component. Inline literals create a new reference on every render, which forces unnecessary re-renders of the PiP internals.
+> Note that `disabled` only disables dragging and scaling — `onPress` still fires on tap.
+
 ### 🔻 `DestroyArea`
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ export default function App() {
 
 > 💡 **Tip:** Object props (`layout`, `destroyArea`, `initialPosition`, `edgeHandle`) and callbacks (`onPress`, `onDestroy`) should be memoized (`useMemo` / `useCallback`) in the consuming component. Inline literals create a new reference on every render, which forces unnecessary re-renders of the PiP internals.
 > Note that `disabled` only disables dragging and scaling — `onPress` still fires on tap.
+> A tap on interactive content **inside** the PiP (buttons, pressables) also counts as a tap on the PiP itself — `onPress` fires alongside the child's own press handler.
 
 ### 🔻 `DestroyArea`
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,12 @@
 module.exports = {
   presets: ['module:react-native-builder-bob/babel-preset'],
+  plugins: [
+    [
+      'babel-plugin-react-compiler',
+      {
+        target: '19',
+        panicThreshold: 'all_errors',
+      },
+    ],
+  ],
 };

--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -8,6 +8,15 @@ module.exports = function (api) {
     // filename was passed to Babel"). The library source is still aliased
     // via builder-bob's metro-config and compiled by babel-preset-expo.
     presets: ['babel-preset-expo'],
-    plugins: ['react-native-worklets/plugin'],
+    plugins: [
+      [
+        'babel-plugin-react-compiler',
+        {
+          target: '19',
+          panicThreshold: 'all_errors',
+        },
+      ],
+      'react-native-worklets/plugin',
+    ],
   };
 };

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,64 +1,52 @@
 import { useState } from 'react';
-import {
-  Pressable,
-  StyleSheet,
-  Text,
-  useWindowDimensions,
-  View,
-} from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { PiPView } from 'react-native-pip-view';
 
-const TOP_BAR_HEIGHT = 54;
-const PIP_SIZE = 54;
+import { BasicScreen } from './screens/BasicScreen';
+import { CustomHandlesScreen } from './screens/CustomHandlesScreen';
+import { DestroyAreaScreen } from './screens/DestroyAreaScreen';
+import { DisabledScreen } from './screens/DisabledScreen';
+import { HideableScreen } from './screens/HideableScreen';
+import { PositionsScreen } from './screens/PositionsScreen';
+
+const SCREENS = [
+  { key: 'basic', title: 'Basic', component: BasicScreen },
+  { key: 'hideable', title: 'Hideable', component: HideableScreen },
+  { key: 'handles', title: 'Custom handles', component: CustomHandlesScreen },
+  { key: 'destroy', title: 'Destroy area', component: DestroyAreaScreen },
+  { key: 'disabled', title: 'Disabled', component: DisabledScreen },
+  { key: 'positions', title: 'Positions', component: PositionsScreen },
+] as const;
+
+type ScreenKey = (typeof SCREENS)[number]['key'];
 
 export default function App() {
-  const { width, height } = useWindowDimensions();
-  const [leftTaps, setLeftTaps] = useState(0);
-  const [centerTaps, setCenterTaps] = useState(0);
-  const [pipPresses, setPipPresses] = useState(0);
+  const [screenKey, setScreenKey] = useState<ScreenKey>('basic');
+  const screen = SCREENS.find((item) => item.key === screenKey) ?? SCREENS[0];
+  const Screen = screen.component;
 
   return (
     <GestureHandlerRootView style={styles.root}>
-      <View style={styles.container}>
-        <View style={styles.topBar} testID="top-bar">
-          <Pressable
-            testID="top-bar-left-button"
-            style={styles.topBarButton}
-            onPress={() => setLeftTaps((count) => count + 1)}
-          >
-            <Text style={styles.topBarButtonText}>L:{leftTaps}</Text>
-          </Pressable>
-          <Pressable
-            testID="top-bar-center-button"
-            style={styles.topBarButton}
-            onPress={() => setCenterTaps((count) => count + 1)}
-          >
-            <Text style={styles.topBarButtonText}>C:{centerTaps}</Text>
-          </Pressable>
-          <Text style={styles.topBarButtonText}>PiP:{pipPresses}</Text>
-        </View>
-
-        <View style={styles.pipWrapper} pointerEvents="box-none">
-          <PiPView
-            hideable={false}
-            snapToEdges
-            onPress={() => setPipPresses((count) => count + 1)}
-            initialPosition={{ x: 'right', y: 'top' }}
-            layout={{
-              width: width,
-              height: height - 140,
-              y: 100,
-              x: 0,
-              horizontalOffset: 12,
-            }}
-          >
-            <View style={styles.pipContainer} testID="pip-element">
-              <View style={styles.circle} />
-            </View>
-          </PiPView>
-        </View>
+      <View style={styles.tabs}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.tabsContent}
+        >
+          {SCREENS.map((item) => (
+            <Pressable
+              key={item.key}
+              testID={`tab-${item.key}`}
+              style={[styles.tab, item.key === screenKey && styles.tabActive]}
+              onPress={() => setScreenKey(item.key)}
+            >
+              <Text style={styles.tabText}>{item.title}</Text>
+            </Pressable>
+          ))}
+        </ScrollView>
       </View>
+
+      <Screen key={screen.key} />
     </GestureHandlerRootView>
   );
 }
@@ -67,49 +55,27 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: '#000',
-  },
-  container: {
-    flexGrow: 1,
     paddingTop: 60,
   },
-  topBar: {
-    height: TOP_BAR_HEIGHT,
-    width: '100%',
-    backgroundColor: 'rgba(80, 120, 255, 0.35)',
-    flexDirection: 'row',
+  tabs: {
+    height: 44,
+  },
+  tabsContent: {
     alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 16,
+    paddingHorizontal: 12,
+    gap: 8,
   },
-  topBarButton: {
-    backgroundColor: 'rgba(255, 255, 255, 0.25)',
-    borderRadius: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-  },
-  topBarButtonText: {
-    color: '#fff',
-    fontVariant: ['tabular-nums'],
-  },
-  pipWrapper: {
-    ...StyleSheet.absoluteFill,
-    top: 60,
-  },
-  pipContainer: {
-    width: PIP_SIZE,
-    height: PIP_SIZE,
-    backgroundColor: 'rgba(255, 255, 255, 0.15)',
-    borderRadius: PIP_SIZE / 2,
-    borderWidth: 1,
-    borderColor: 'rgba(255, 255, 255, 0.4)',
-    overflow: 'hidden',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  circle: {
-    width: 32,
-    height: 32,
-    backgroundColor: 'rgba(120, 255, 160, 0.5)',
+  tab: {
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
     borderRadius: 16,
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+  },
+  tabActive: {
+    backgroundColor: 'rgba(80, 120, 255, 0.55)',
+  },
+  tabText: {
+    color: '#fff',
+    fontSize: 13,
   },
 });

--- a/example/src/screens/BasicScreen.tsx
+++ b/example/src/screens/BasicScreen.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { PiPView } from 'react-native-pip-view';
+
+import {
+  DragAreaIndicator,
+  PipContent,
+  ScreenInfo,
+  usePipLayout,
+} from './shared';
+
+export const BasicScreen = () => {
+  const layout = usePipLayout(40, 260);
+  const [leftTaps, setLeftTaps] = useState(0);
+  const [centerTaps, setCenterTaps] = useState(0);
+  const [pipPresses, setPipPresses] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <ScreenInfo>
+        snapToEdges, hideable=false. Tap increments PiP:N. Pushing against the
+        side edges applies resistance (no overdrag). Pinch snaps the scale to
+        0.7/1/1.3.
+      </ScreenInfo>
+
+      <View style={styles.topBar} testID="top-bar">
+        <Pressable
+          testID="top-bar-left-button"
+          style={styles.topBarButton}
+          onPress={() => setLeftTaps((count) => count + 1)}
+        >
+          <Text style={styles.topBarButtonText}>L:{leftTaps}</Text>
+        </Pressable>
+        <Pressable
+          testID="top-bar-center-button"
+          style={styles.topBarButton}
+          onPress={() => setCenterTaps((count) => count + 1)}
+        >
+          <Text style={styles.topBarButtonText}>C:{centerTaps}</Text>
+        </Pressable>
+        <Text style={styles.topBarButtonText}>PiP:{pipPresses}</Text>
+      </View>
+
+      <View style={styles.pipWrapper} pointerEvents="box-none">
+        <DragAreaIndicator layout={layout} />
+        <PiPView
+          hideable={false}
+          snapToEdges
+          onPress={() => setPipPresses((count) => count + 1)}
+          initialPosition={{ x: 'right', y: 'top' }}
+          layout={layout}
+        >
+          <PipContent label={`PiP:${pipPresses}`} />
+        </PiPView>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  topBar: {
+    height: 54,
+    width: '100%',
+    backgroundColor: 'rgba(80, 120, 255, 0.35)',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+  },
+  topBarButton: {
+    backgroundColor: 'rgba(255, 255, 255, 0.25)',
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  topBarButtonText: {
+    color: '#fff',
+    fontVariant: ['tabular-nums'],
+  },
+  pipWrapper: {
+    ...StyleSheet.absoluteFill,
+  },
+});

--- a/example/src/screens/CustomHandlesScreen.tsx
+++ b/example/src/screens/CustomHandlesScreen.tsx
@@ -1,0 +1,66 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { PiPView } from 'react-native-pip-view';
+
+import {
+  DragAreaIndicator,
+  PipContent,
+  ScreenInfo,
+  usePipLayout,
+} from './shared';
+
+const Handle = ({ arrow }: { arrow: string }) => (
+  <View style={styles.handle}>
+    <Text style={styles.handleText}>{arrow}</Text>
+  </View>
+);
+
+export const CustomHandlesScreen = () => {
+  const layout = usePipLayout();
+
+  return (
+    <View style={styles.container}>
+      <ScreenInfo>
+        hideable + custom edgeHandle (left/right). Hide the PiP past a side edge
+        — a custom handle shows up instead of the default arrow.
+      </ScreenInfo>
+
+      <View style={styles.pipWrapper} pointerEvents="box-none">
+        <DragAreaIndicator layout={layout} />
+        <PiPView
+          hideable
+          snapToEdges
+          initialPosition={{ x: 'right', y: 'center' }}
+          layout={layout}
+          edgeHandle={{
+            left: <Handle arrow="›" />,
+            right: <Handle arrow="‹" />,
+          }}
+        >
+          <PipContent size={96} label="custom" />
+        </PiPView>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  pipWrapper: {
+    ...StyleSheet.absoluteFill,
+  },
+  handle: {
+    width: 28,
+    height: 72,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255, 120, 120, 0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  handleText: {
+    color: '#fff',
+    fontSize: 22,
+    fontWeight: '700',
+  },
+});

--- a/example/src/screens/DestroyAreaScreen.tsx
+++ b/example/src/screens/DestroyAreaScreen.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+import { PiPView } from 'react-native-pip-view';
+
+import {
+  DragAreaIndicator,
+  PipContent,
+  ScreenInfo,
+  usePipLayout,
+} from './shared';
+
+const DESTROY_AREA_HEIGHT = 110;
+const ROOT_TOP_PADDING = 60;
+const DESTROY_AREA_BOTTOM_MARGIN = 30;
+
+export const DestroyAreaScreen = () => {
+  const { width, height } = useWindowDimensions();
+  // Bottom inset small enough that the drag area overlaps the destroy
+  // area — the PiP must reach it without fighting the edge resistance.
+  const layout = usePipLayout(70);
+  const [visible, setVisible] = useState(true);
+  const [destroyCount, setDestroyCount] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <ScreenInfo>
+        destroyArea + onDestroy + hideable, numeric initialPosition (x: 12, y:
+        12). Drop the PiP onto the highlighted area at the bottom — it shrinks
+        to zero and disappears (onDestroy fires after ~150 ms). Destroyed:{' '}
+        {destroyCount}
+      </ScreenInfo>
+
+      {!visible && (
+        <Pressable
+          style={styles.respawnButton}
+          onPress={() => setVisible(true)}
+        >
+          <Text style={styles.respawnText}>Respawn PiP</Text>
+        </Pressable>
+      )}
+
+      <View style={styles.pipWrapper} pointerEvents="box-none">
+        <DragAreaIndicator layout={layout} />
+        {visible && (
+          <PiPView
+            hideable
+            snapToEdges
+            initialPosition={{ x: 12, y: 12 }}
+            layout={layout}
+            destroyArea={{
+              layout: {
+                x: 24,
+                y:
+                  height -
+                  ROOT_TOP_PADDING -
+                  DESTROY_AREA_BOTTOM_MARGIN -
+                  DESTROY_AREA_HEIGHT,
+                width: width - 48,
+                height: DESTROY_AREA_HEIGHT,
+              },
+              activeColor: 'rgba(255, 80, 80, 0.35)',
+              inactiveColor: 'rgba(255, 255, 255, 0.08)',
+            }}
+            onDestroy={() => {
+              setVisible(false);
+              setDestroyCount((count) => count + 1);
+            }}
+          >
+            <PipContent label="drop me" />
+          </PiPView>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  pipWrapper: {
+    ...StyleSheet.absoluteFill,
+  },
+  respawnButton: {
+    alignSelf: 'center',
+    marginTop: 24,
+    backgroundColor: 'rgba(120, 255, 160, 0.25)',
+    borderColor: 'rgba(120, 255, 160, 0.6)',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+  },
+  respawnText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});

--- a/example/src/screens/DestroyAreaScreen.tsx
+++ b/example/src/screens/DestroyAreaScreen.tsx
@@ -11,12 +11,12 @@ import { PiPView } from 'react-native-pip-view';
 import {
   DragAreaIndicator,
   PipContent,
+  ROOT_TOP_PADDING,
   ScreenInfo,
   usePipLayout,
 } from './shared';
 
 const DESTROY_AREA_HEIGHT = 110;
-const ROOT_TOP_PADDING = 60;
 const DESTROY_AREA_BOTTOM_MARGIN = 30;
 
 export const DestroyAreaScreen = () => {

--- a/example/src/screens/DisabledScreen.tsx
+++ b/example/src/screens/DisabledScreen.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import { Pressable, StyleSheet, Switch, Text, View } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
+import { PiPView } from 'react-native-pip-view';
+
+import {
+  DragAreaIndicator,
+  PipContent,
+  ScreenInfo,
+  usePipLayout,
+} from './shared';
+
+const BLOCK_COLORS = ['#f66', '#fa6', '#fd6', '#6f9', '#6cf', '#96f'];
+
+export const DisabledScreen = () => {
+  const layout = usePipLayout(40, 260);
+  const [disabled, setDisabled] = useState(true);
+  const [innerTaps, setInnerTaps] = useState(0);
+  const [pipPresses, setPipPresses] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <ScreenInfo>
+        disabled — pan and pinch are off, onPress still works (PiP:
+        {pipPresses}). The scroll view and the button INSIDE the PiP must keep
+        working when disabled=true (gestures must not steal touches). Toggle and
+        compare.
+      </ScreenInfo>
+
+      <View style={styles.switchRow}>
+        <Text style={styles.switchLabel}>disabled: {String(disabled)}</Text>
+        <Switch value={disabled} onValueChange={setDisabled} />
+      </View>
+
+      <View style={styles.pipWrapper} pointerEvents="box-none">
+        <DragAreaIndicator layout={layout} />
+        <PiPView
+          disabled={disabled}
+          hideable={false}
+          snapToEdges
+          onPress={() => setPipPresses((count) => count + 1)}
+          initialPosition={{ x: 'center', y: 'center' }}
+          layout={layout}
+        >
+          <PipContent size={132} style={styles.pipContent}>
+            <Pressable
+              style={styles.innerButton}
+              onPress={() => setInnerTaps((count) => count + 1)}
+            >
+              <Text style={styles.innerButtonText}>inner:{innerTaps}</Text>
+            </Pressable>
+
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              style={styles.scroll}
+            >
+              {BLOCK_COLORS.map((color) => (
+                <View
+                  key={color}
+                  style={[styles.block, { backgroundColor: color }]}
+                />
+              ))}
+            </ScrollView>
+          </PipContent>
+        </PiPView>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 4,
+  },
+  switchLabel: {
+    color: '#fff',
+  },
+  pipWrapper: {
+    ...StyleSheet.absoluteFill,
+  },
+  pipContent: {
+    padding: 8,
+    justifyContent: 'space-between',
+  },
+  innerButton: {
+    backgroundColor: 'rgba(255, 255, 255, 0.25)',
+    borderRadius: 8,
+    paddingVertical: 6,
+    alignItems: 'center',
+    alignSelf: 'stretch',
+  },
+  innerButtonText: {
+    color: '#fff',
+    fontVariant: ['tabular-nums'],
+  },
+  scroll: {
+    flexGrow: 0,
+  },
+  block: {
+    width: 36,
+    height: 36,
+    borderRadius: 6,
+    marginRight: 6,
+  },
+});

--- a/example/src/screens/HideableScreen.tsx
+++ b/example/src/screens/HideableScreen.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { PiPView, PiPViewBlurOverlay } from 'react-native-pip-view';
+
+import {
+  DragAreaIndicator,
+  PipContent,
+  ScreenInfo,
+  usePipLayout,
+} from './shared';
+
+export const HideableScreen = () => {
+  const layout = usePipLayout();
+  const [pipPresses, setPipPresses] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <ScreenInfo>
+        hideable + snapToEdges + PiPViewBlurOverlay. Drag far past a side edge
+        (overdrag) or flick fast — the PiP docks off-screen and shows an arrow
+        handle. Tap the handle to bring it back. The content blurs during
+        overdrag.
+      </ScreenInfo>
+
+      <View style={styles.pipWrapper} pointerEvents="box-none">
+        <DragAreaIndicator layout={layout} />
+        <PiPView
+          hideable
+          snapToEdges
+          onPress={() => setPipPresses((count) => count + 1)}
+          initialPosition={{ x: 'left', y: 'top' }}
+          layout={layout}
+        >
+          <PipContent size={96}>
+            <Text style={styles.label}>PiP:{pipPresses}</Text>
+            <PiPViewBlurOverlay />
+          </PipContent>
+        </PiPView>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  pipWrapper: {
+    ...StyleSheet.absoluteFill,
+  },
+  label: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});

--- a/example/src/screens/PositionsScreen.tsx
+++ b/example/src/screens/PositionsScreen.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { PiPView, type PiPViewInitialPosition } from 'react-native-pip-view';
+
+import {
+  DragAreaIndicator,
+  PipContent,
+  ScreenInfo,
+  usePipLayout,
+} from './shared';
+
+const X_OPTIONS = ['left', 'center', 'right', 24] as const;
+const Y_OPTIONS = ['top', 'center', 'bottom', 24] as const;
+
+export const PositionsScreen = () => {
+  const layout = usePipLayout(40, 280);
+  const [x, setX] = useState<PiPViewInitialPosition['x']>('right');
+  const [y, setY] = useState<PiPViewInitialPosition['y']>('bottom');
+
+  return (
+    <View style={styles.container}>
+      <ScreenInfo>
+        initialPosition variants (named and numeric) + snapToEdges=false — on
+        release Y stays where you left it (clamped only), X still snaps to an
+        edge. Picking an option remounts the PiP.
+      </ScreenInfo>
+
+      <View style={styles.optionsRow}>
+        <Text style={styles.optionsLabel}>x:</Text>
+        {X_OPTIONS.map((option) => (
+          <Pressable
+            key={String(option)}
+            style={[styles.option, x === option && styles.optionActive]}
+            onPress={() => setX(option)}
+          >
+            <Text style={styles.optionText}>{String(option)}</Text>
+          </Pressable>
+        ))}
+      </View>
+      <View style={styles.optionsRow}>
+        <Text style={styles.optionsLabel}>y:</Text>
+        {Y_OPTIONS.map((option) => (
+          <Pressable
+            key={String(option)}
+            style={[styles.option, y === option && styles.optionActive]}
+            onPress={() => setY(option)}
+          >
+            <Text style={styles.optionText}>{String(option)}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={styles.pipWrapper} pointerEvents="box-none">
+        <DragAreaIndicator layout={layout} />
+        <PiPView
+          key={`${x}-${y}`}
+          hideable={false}
+          snapToEdges={false}
+          initialPosition={{ x, y }}
+          layout={layout}
+        >
+          <PipContent label={`${x}/${y}`} />
+        </PiPView>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  optionsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 4,
+    gap: 8,
+  },
+  optionsLabel: {
+    color: '#fff',
+    width: 16,
+  },
+  option: {
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  optionActive: {
+    backgroundColor: 'rgba(120, 255, 160, 0.35)',
+  },
+  optionText: {
+    color: '#fff',
+  },
+  pipWrapper: {
+    ...StyleSheet.absoluteFill,
+  },
+});

--- a/example/src/screens/shared.tsx
+++ b/example/src/screens/shared.tsx
@@ -13,7 +13,7 @@ export const HEADER_HEIGHT = 200;
 // Root view has paddingTop: 60, and the pip wrapper (absoluteFill) lives
 // inside it — layout coordinates are relative to the wrapper, so absolute
 // screen positions need to be shifted by this padding.
-const ROOT_TOP_PADDING = 60;
+export const ROOT_TOP_PADDING = 60;
 
 export const usePipLayout = (bottomInset = 40, topOffset = HEADER_HEIGHT) => {
   const { width, height } = useWindowDimensions();

--- a/example/src/screens/shared.tsx
+++ b/example/src/screens/shared.tsx
@@ -1,0 +1,113 @@
+import { type PropsWithChildren } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+
+export const HEADER_HEIGHT = 200;
+
+// Root view has paddingTop: 60, and the pip wrapper (absoluteFill) lives
+// inside it — layout coordinates are relative to the wrapper, so absolute
+// screen positions need to be shifted by this padding.
+const ROOT_TOP_PADDING = 60;
+
+export const usePipLayout = (bottomInset = 40, topOffset = HEADER_HEIGHT) => {
+  const { width, height } = useWindowDimensions();
+
+  return {
+    x: 0,
+    y: topOffset - ROOT_TOP_PADDING,
+    width,
+    // getEdges treats layout.height as the BOTTOM boundary coordinate
+    // (maxY = height - elementHeight - horizontalOffset), not a relative
+    // height.
+    height: height - ROOT_TOP_PADDING - bottomInset,
+    horizontalOffset: 12,
+  };
+};
+
+type PipLayout = ReturnType<typeof usePipLayout>;
+
+export const DragAreaIndicator = ({ layout }: { layout: PipLayout }) => {
+  const offset = layout.horizontalOffset ?? 0;
+
+  return (
+    <View
+      pointerEvents="none"
+      style={[
+        styles.dragArea,
+        {
+          left: layout.x + offset,
+          top: layout.y,
+          width: layout.width - layout.x - offset * 2,
+          height: layout.height - offset - layout.y,
+        },
+      ]}
+    />
+  );
+};
+
+export const ScreenInfo = ({ children }: PropsWithChildren) => (
+  <View style={styles.info}>
+    <Text style={styles.infoText}>{children}</Text>
+  </View>
+);
+
+interface PipContentProps {
+  label?: string;
+  size?: number;
+  style?: StyleProp<ViewStyle>;
+}
+
+export const PipContent = ({
+  label,
+  size = 84,
+  style,
+  children,
+}: PropsWithChildren<PipContentProps>) => (
+  <View
+    testID="pip-element"
+    style={[
+      styles.pipContainer,
+      { width: size, height: size, borderRadius: size / 4 },
+      style,
+    ]}
+  >
+    {children ?? <Text style={styles.pipLabel}>{label ?? 'PiP'}</Text>}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  dragArea: {
+    position: 'absolute',
+    backgroundColor: 'rgba(80, 120, 255, 0.06)',
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: 'rgba(80, 120, 255, 0.3)',
+    borderRadius: 12,
+  },
+  info: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  infoText: {
+    color: 'rgba(255, 255, 255, 0.6)',
+    fontSize: 12,
+  },
+  pipContainer: {
+    backgroundColor: 'rgba(120, 255, 160, 0.25)',
+    borderWidth: 1,
+    borderColor: 'rgba(120, 255, 160, 0.6)',
+    overflow: 'hidden',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pipLabel: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-pip-view",
   "version": "0.3.11",
   "description": "Custom PiP View component",
-  "source": "./src/index.tsx",
+  "source": "./src/index.ts",
   "main": "lib/commonjs/index.js",
   "types": "lib/typescript/src/index.d.ts",
   "files": [
@@ -48,6 +48,7 @@
     "@release-it/conventional-changelog": "^11.0.1",
     "@types/jest": "^29.5.14",
     "@types/react": "19.2.17",
+    "babel-plugin-react-compiler": "^1.0.0",
     "commitlint": "^21.0.2",
     "del-cli": "^7.0.0",
     "eslint": "^9.39.4",
@@ -122,7 +123,12 @@
     "source": "src",
     "output": "lib",
     "targets": [
-      "commonjs",
+      [
+        "commonjs",
+        {
+          "configFile": true
+        }
+      ],
       "typescript"
     ]
   },

--- a/src/components/ArrowButton.tsx
+++ b/src/components/ArrowButton.tsx
@@ -14,10 +14,8 @@ interface Props {
 }
 
 export const ArrowButton = ({ side }: Props) => {
-  const { edgeHandleLayout, edgeHandle } = usePiPViewContext((state) => ({
-    edgeHandleLayout: state.edgeHandleLayout,
-    edgeHandle: state.edgeHandle,
-  }));
+  const edgeHandleLayout = usePiPViewContext((state) => state.edgeHandleLayout);
+  const edgeHandle = usePiPViewContext((state) => state.edgeHandle);
 
   const containerStyles = useAnimatedStyle(() => ({
     borderTopRightRadius: side === 'right' ? 8 : 0,
@@ -44,10 +42,10 @@ export const ArrowButton = ({ side }: Props) => {
       return;
     }
 
-    edgeHandleLayout.value = {
+    edgeHandleLayout.set({
       width: event.nativeEvent.layout.width,
       height: event.nativeEvent.layout.height,
-    };
+    });
   };
 
   return (

--- a/src/components/CustomEdgeHandle.tsx
+++ b/src/components/CustomEdgeHandle.tsx
@@ -12,13 +12,9 @@ interface Props {
 }
 
 export const CustomEdgeHandle = ({ side }: Props) => {
-  const { edgeHandle, edgeHandleLayout, elementLayout } = usePiPViewContext(
-    (state) => ({
-      edgeHandle: state.edgeHandle,
-      edgeHandleLayout: state.edgeHandleLayout,
-      elementLayout: state.elementLayout,
-    })
-  );
+  const edgeHandle = usePiPViewContext((state) => state.edgeHandle);
+  const edgeHandleLayout = usePiPViewContext((state) => state.edgeHandleLayout);
+  const elementLayout = usePiPViewContext((state) => state.elementLayout);
 
   const leftHandleStyle = useAnimatedStyle(() => ({
     opacity: withTiming(side === 'left' ? 1 : 0),
@@ -42,17 +38,17 @@ export const CustomEdgeHandle = ({ side }: Props) => {
   }));
 
   const onLayoutLeftHandle = (event: LayoutChangeEvent) => {
-    edgeHandleLayout.value = {
+    edgeHandleLayout.set({
       width: event.nativeEvent.layout.width,
       height: event.nativeEvent.layout.height,
-    };
+    });
   };
 
   const onLayoutRightHandle = (event: LayoutChangeEvent) => {
-    edgeHandleLayout.value = {
+    edgeHandleLayout.set({
       width: event.nativeEvent.layout.width,
       height: event.nativeEvent.layout.height,
-    };
+    });
   };
 
   if (!edgeHandle?.left || !edgeHandle?.right) {

--- a/src/components/EdgeHandle.tsx
+++ b/src/components/EdgeHandle.tsx
@@ -33,10 +33,8 @@ export const EdgeHandle = ({
   style,
   side,
 }: Props) => {
-  const { edgeHandle, elementLayout } = usePiPViewContext((state) => ({
-    edgeHandle: state.edgeHandle,
-    elementLayout: state.elementLayout,
-  }));
+  const edgeHandle = usePiPViewContext((state) => state.edgeHandle);
+  const elementLayout = usePiPViewContext((state) => state.elementLayout);
 
   const containerStyle = useAnimatedStyle(() => ({
     height: elementLayout.value.height,

--- a/src/components/LeftEdgeHandle.tsx
+++ b/src/components/LeftEdgeHandle.tsx
@@ -9,25 +9,15 @@ interface Props {
 }
 
 export const LeftEdgeHandle = ({ onPress }: Props) => {
-  const { dockSide, overDragSide, edgeHandleLayout } = usePiPViewContext(
-    (state) => ({
-      onPress: state.onPress,
-      overDragSide: state.overDragSide,
-      dockSide: state.dockSide,
-      elementLayout: state.elementLayout,
-      edgeHandleLayout: state.edgeHandleLayout,
-    })
-  );
+  const dockSide = usePiPViewContext((state) => state.dockSide);
+  const overDragSide = usePiPViewContext((state) => state.overDragSide);
+  const edgeHandleLayout = usePiPViewContext((state) => state.edgeHandleLayout);
 
   const translateX = useDerivedValue<number>(() => {
-    switch (true) {
-      case overDragSide.value === 'left':
-        return edgeHandleLayout.value.width;
-      case dockSide.value === 'left':
-        return edgeHandleLayout.value.width;
-      default:
-        return 0;
+    if (overDragSide.value === 'left' || dockSide.value === 'left') {
+      return edgeHandleLayout.value.width;
     }
+    return 0;
   });
 
   const isVisible = useDerivedValue(

--- a/src/components/PiPView.tsx
+++ b/src/components/PiPView.tsx
@@ -1,19 +1,28 @@
-import { useCallback, useMemo, type PropsWithChildren } from 'react';
+import { type PropsWithChildren } from 'react';
 import { type LayoutRectangle } from 'react-native';
 import { useDerivedValue, useSharedValue } from 'react-native-reanimated';
 
 import { type Dimensions, type EdgeSide, type PiPViewProps } from '../models';
 import { PiPViewProvider } from '../context/PiPView.provider';
 import { PiPViewImpl } from './PiPViewImpl';
-import { getEdges } from '../utils';
+import { getEdges } from '../utils/snapping';
 import { useInitialPosition } from '../hooks/useInitialPosition';
+
+const OVER_DRAG_OFFSET_MULTIPLIER = 0.4;
+const DESTROY_CALLBACK_DELAY_MS = 150;
 
 export const PiPView = ({
   children,
-  ...props
+  disabled,
+  destroyArea,
+  initialPosition,
+  hideable,
+  layout,
+  snapToEdges,
+  edgeHandle,
+  onDestroy,
+  onPress,
 }: PropsWithChildren<PiPViewProps>) => {
-  const { layout, initialPosition, onDestroy, edgeHandle } = props;
-
   const dockSide = useSharedValue<EdgeSide | null>(null);
 
   const elementLayout = useSharedValue<LayoutRectangle>({
@@ -58,70 +67,59 @@ export const PiPView = ({
     return getEdges(layout, scaledElementLayout);
   });
 
-  const positionValues = useInitialPosition({
-    initialPosition,
-    edges,
-    isInitialized,
-    layout,
-  });
+  const { translationX, translationY, prevTranslationX, prevTranslationY } =
+    useInitialPosition({
+      initialPosition,
+      edges,
+      isInitialized,
+      layout,
+    });
 
   const overDragOffset = useDerivedValue(
-    () => scaledElementLayout.value.width * 0.4
+    () => scaledElementLayout.value.width * OVER_DRAG_OFFSET_MULTIPLIER
   );
 
   const overDragSide = useSharedValue<EdgeSide | null>(null);
 
-  const handleDestroy = useCallback(() => {
-    isDestroyed.value = true;
+  const handleDestroy = () => {
+    isDestroyed.set(true);
 
-    const timeout = setTimeout(() => {
+    setTimeout(() => {
       onDestroy?.();
-    }, 150);
+    }, DESTROY_CALLBACK_DELAY_MS);
+  };
 
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [isDestroyed, onDestroy]);
-
-  const contextValue = useMemo(
-    () => ({
-      dockSide,
-      overDragSide,
-      scale,
-      elementLayout,
-      scaledElementLayout,
-      isPanActive,
-      isHighlightAreaActive,
-      isDestroyed,
-      isInitialized,
-      edges,
-      overDragOffset,
-      handleDestroy,
-      edgeHandleLayout,
-      ...positionValues,
-      ...props,
-    }),
-    [
-      dockSide,
-      overDragSide,
-      scale,
-      elementLayout,
-      isPanActive,
-      overDragOffset,
-      handleDestroy,
-      isHighlightAreaActive,
-      scaledElementLayout,
-      isDestroyed,
-      positionValues,
-      isInitialized,
-      edgeHandleLayout,
-      edges,
-      props,
-    ]
-  );
+  const contextValue = {
+    disabled,
+    destroyArea,
+    initialPosition,
+    hideable,
+    layout,
+    snapToEdges,
+    edgeHandle,
+    onDestroy,
+    onPress,
+    dockSide,
+    overDragSide,
+    scale,
+    elementLayout,
+    scaledElementLayout,
+    isPanActive,
+    isHighlightAreaActive,
+    isDestroyed,
+    isInitialized,
+    edges,
+    overDragOffset,
+    handleDestroy,
+    edgeHandleLayout,
+    translationX,
+    translationY,
+    prevTranslationX,
+    prevTranslationY,
+  };
 
   return (
-    <PiPViewProvider {...contextValue}>
+    <PiPViewProvider value={contextValue}>
       <PiPViewImpl>{children}</PiPViewImpl>
     </PiPViewProvider>
   );

--- a/src/components/PiPView.tsx
+++ b/src/components/PiPView.tsx
@@ -60,11 +60,31 @@ export const PiPView = ({
     height: elementLayout.value.height * scale.value,
   }));
 
+  // Primitives keep the worklet closure stable when the consumer passes
+  // a new (but equal) `layout` object on re-render — otherwise this
+  // derived value would be re-registered on every render.
+  const {
+    x: layoutX,
+    y: layoutY,
+    width: layoutWidth,
+    height: layoutHeight,
+    horizontalOffset: layoutHorizontalOffset,
+  } = layout;
+
   const edges = useDerivedValue(() => {
     if (!isInitialized.value) {
       return null;
     }
-    return getEdges(layout, scaledElementLayout);
+    return getEdges(
+      {
+        x: layoutX,
+        y: layoutY,
+        width: layoutWidth,
+        height: layoutHeight,
+        horizontalOffset: layoutHorizontalOffset,
+      },
+      scaledElementLayout
+    );
   });
 
   const { translationX, translationY, prevTranslationX, prevTranslationY } =

--- a/src/components/PiPViewBlurOverlay.tsx
+++ b/src/components/PiPViewBlurOverlay.tsx
@@ -26,7 +26,7 @@ export const PiPViewBlurOverlay = ({ style }: Props) => {
         style={StyleSheet.absoluteFill}
         intensity={20}
         tint="dark"
-        blurMethod="dimezisBlurViewSdk31Plus"
+        experimentalBlurMethod="dimezisBlurView"
       />
     </Animated.View>
   );

--- a/src/components/PiPViewBlurOverlay.tsx
+++ b/src/components/PiPViewBlurOverlay.tsx
@@ -26,7 +26,7 @@ export const PiPViewBlurOverlay = ({ style }: Props) => {
         style={StyleSheet.absoluteFill}
         intensity={20}
         tint="dark"
-        experimentalBlurMethod="dimezisBlurView"
+        blurMethod="dimezisBlurViewSdk31Plus"
       />
     </Animated.View>
   );

--- a/src/components/PiPViewImpl.tsx
+++ b/src/components/PiPViewImpl.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type PropsWithChildren } from 'react';
+import { type PropsWithChildren } from 'react';
 import { StyleSheet, type LayoutChangeEvent } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
@@ -8,64 +8,54 @@ import Animated, {
   withDelay,
   withSpring,
   withTiming,
-  type SharedValue,
 } from 'react-native-reanimated';
 
 import { animationsPresets } from '../constants';
 import { LeftEdgeHandle } from './LeftEdgeHandle';
-import { type ContainerLayoutRectangle, type Dimensions } from '../models';
 import { usePiPViewContext } from '../context/PiPView.provider';
 import { RightEdgeHandle } from './RightEdgeHandle';
-import { getEdges } from '../utils';
+import { getCurrentHorizontalSide, getEdges } from '../utils/snapping';
 import { usePanGesture } from '../hooks/usePanGesture';
 import { usePinchGesture } from '../hooks/usePinchGesture';
 import { useDragHelpers } from '../hooks/useDragHelpers';
 
 export const PiPViewImpl = ({ children }: PropsWithChildren) => {
-  const {
-    elementLayout,
-    scaledElementLayout,
-    isDestroyed,
-    layout,
-    dockSide,
-    translationX,
-    translationY,
-    isInitialized,
-    edges,
-    overDragSide,
-    isHighlightAreaActive,
-    isPanActive,
-    onPress,
-    scale,
-    destroyArea,
-    edgeHandleLayout,
-  } = usePiPViewContext((state) => ({
-    elementLayout: state.elementLayout,
-    overDragSide: state.overDragSide,
-    onDestroy: state.onDestroy,
-    initialPosition: state.initialPosition,
-    edges: state.edges,
-    isInitialized: state.isInitialized,
-    scaledElementLayout: state.scaledElementLayout,
-    isDestroyed: state.isDestroyed,
-    destroyArea: state.destroyArea,
-    layout: state.layout,
-    translationY: state.translationY,
-    translationX: state.translationX,
-    dockSide: state.dockSide,
-    isHighlightAreaActive: state.isHighlightAreaActive,
-    onPress: state.onPress,
-    isPanActive: state.isPanActive,
-    scale: state.scale,
-    edgeHandleLayout: state.edgeHandleLayout,
-  }));
-
-  const handleLayoutChange = useCallback(
-    (event: LayoutChangeEvent) => {
-      elementLayout.value = event.nativeEvent.layout;
-    },
-    [elementLayout]
+  const elementLayout = usePiPViewContext((state) => state.elementLayout);
+  const scaledElementLayout = usePiPViewContext(
+    (state) => state.scaledElementLayout
   );
+  const isDestroyed = usePiPViewContext((state) => state.isDestroyed);
+  const layout = usePiPViewContext((state) => state.layout);
+  const dockSide = usePiPViewContext((state) => state.dockSide);
+  const translationX = usePiPViewContext((state) => state.translationX);
+  const translationY = usePiPViewContext((state) => state.translationY);
+  const isInitialized = usePiPViewContext((state) => state.isInitialized);
+  const edges = usePiPViewContext((state) => state.edges);
+  const overDragSide = usePiPViewContext((state) => state.overDragSide);
+  const isHighlightAreaActive = usePiPViewContext(
+    (state) => state.isHighlightAreaActive
+  );
+  const isPanActive = usePiPViewContext((state) => state.isPanActive);
+  const onPress = usePiPViewContext((state) => state.onPress);
+  const scale = usePiPViewContext((state) => state.scale);
+  const destroyArea = usePiPViewContext((state) => state.destroyArea);
+  const edgeHandleLayout = usePiPViewContext((state) => state.edgeHandleLayout);
+
+  // Captured as primitives so worklet closures below stay stable across
+  // consumer re-renders that pass a new (but equal) `layout` object —
+  // otherwise the reaction would re-register and snap the PiP on every
+  // render.
+  const {
+    x: layoutX,
+    y: layoutY,
+    width: layoutWidth,
+    height: layoutHeight,
+    horizontalOffset: layoutHorizontalOffset,
+  } = layout;
+
+  const handleLayoutChange = (event: LayoutChangeEvent) => {
+    elementLayout.set(event.nativeEvent.layout);
+  };
 
   const { pan: panGesture, handlePanEnd } = usePanGesture();
   const { pinchGesture } = usePinchGesture({ onEnd: handlePanEnd });
@@ -81,125 +71,124 @@ export const PiPViewImpl = ({ children }: PropsWithChildren) => {
   const offsetX = useDerivedValue(() => diffX.value / 2);
   const offsetY = useDerivedValue(() => diffY.value / 2);
 
-  const getCurrentHorizontalSide = useCallback(
-    (
-      currentContainerLayout: ContainerLayoutRectangle,
-      currentElementLayout: SharedValue<Dimensions>
-    ) => {
-      'worklet';
-      return translationX.value <
-        (currentContainerLayout.width - currentElementLayout.value.width) / 2
-        ? 'left'
-        : 'right';
-    },
-    [translationX]
-  );
+  const handleExpandView = () => {
+    // Guard against double invocation (RNGH tap + the handle's Touchable
+    // can both resolve the same press) — the second call would otherwise
+    // recompute targetX with dockSide already cleared.
+    if (!dockSide.get()) {
+      return;
+    }
 
-  const tapGesture = useMemo(
-    () =>
-      Gesture.Tap()
-        .runOnJS(true)
-        .shouldCancelWhenOutside(true)
-        .onTouchesUp(() => {
-          // This runs on JS thread due to .runOnJS(true)
-          if (dockSide.value) {
-            return;
-          }
-          onPress?.();
-        }),
-    [dockSide, onPress]
-  );
+    const minX = layoutHorizontalOffset ?? 0;
+    const maxX =
+      layoutWidth -
+      scaledElementLayout.get().width -
+      (layoutHorizontalOffset ?? 0);
+
+    const targetX = dockSide.get() === 'left' ? minX : maxX;
+    translationX.set(targetX);
+
+    const targetY = findNearestYEdge(translationY.get());
+    translationY.set(targetY);
+
+    overDragSide.set(null);
+    dockSide.set(null);
+  };
+
+  // `disabled` intentionally does not block the tap — it only disables
+  // dragging and scaling, while `onPress` keeps working.
+  //
+  // No .shouldCancelWhenOutside here: when the PiP is docked, the edge
+  // handle sits OUTSIDE the gesture view's bounds (translated past the
+  // edge), so cancel-when-outside would kill handle taps on Android
+  // (where it defaults to true). .maxDistance covers the
+  // "slide away and release" case instead.
+  const tapGesture = Gesture.Tap()
+    .runOnJS(true)
+    .shouldCancelWhenOutside(false)
+    .maxDistance(24)
+    .onEnd((_event, success) => {
+      // This runs on JS thread due to .runOnJS(true)
+      if (!success) {
+        return;
+      }
+      if (dockSide.get()) {
+        // When docked, this tap wins the race against the edge handle's
+        // Touchable (activation cancels its press), so the gesture itself
+        // must perform the expand — otherwise handle presses get swallowed.
+        handleExpandView();
+        return;
+      }
+      onPress?.();
+    });
 
   const gesture = Gesture.Race(
     tapGesture,
     Gesture.Simultaneous(panGesture, pinchGesture)
   );
 
-  const handleExpandView = useCallback(() => {
-    const minX = layout.horizontalOffset ?? 0;
-    const maxX =
-      layout.width -
-      scaledElementLayout.value.width -
-      (layout.horizontalOffset ?? 0);
-
-    const targetX = dockSide.value === 'left' ? minX : maxX;
-    translationX.value = targetX;
-
-    const targetY = findNearestYEdge(translationY.value);
-    translationY.value = targetY;
-
-    overDragSide.value = null;
-    dockSide.value = null;
-  }, [
-    layout.horizontalOffset,
-    layout.width,
-    scaledElementLayout.value.width,
-    dockSide,
-    translationX,
-    findNearestYEdge,
-    translationY,
-    overDragSide,
-  ]);
-
   useAnimatedReaction(
-    () => ({
-      currentContainerLayout: layout,
-      currentScaledElementLayout: scaledElementLayout,
-    }),
-    ({ currentContainerLayout, currentScaledElementLayout }) => {
+    () => scaledElementLayout.value,
+    (currentScaledElementLayout) => {
       if (!edges.value) {
         return;
       }
       if (translationY.value > edges.value.maxY) {
-        translationY.value = edges.value.maxY;
+        translationY.set(edges.value.maxY);
       }
       if (translationY.value < edges.value.minY) {
-        translationY.value = edges.value.minY;
+        translationY.set(edges.value.minY);
       }
 
       if (!dockSide.value) {
         const currentEdges = getEdges(
-          currentContainerLayout,
-          currentScaledElementLayout
+          {
+            x: layoutX,
+            y: layoutY,
+            width: layoutWidth,
+            height: layoutHeight,
+            horizontalOffset: layoutHorizontalOffset,
+          },
+          scaledElementLayout
         );
         const snapToLeft =
           getCurrentHorizontalSide(
-            currentContainerLayout,
-            currentScaledElementLayout
+            translationX.value,
+            layoutWidth,
+            currentScaledElementLayout.width
           ) === 'left';
         const targetX = snapToLeft ? currentEdges.minX : currentEdges.maxX;
 
-        translationX.value = targetX;
+        translationX.set(targetX);
       }
-    },
-    [edges]
+    }
   );
 
   const animatedStyle = useAnimatedStyle(() => {
     const getOpacity = () => {
-      switch (true) {
-        case !!overDragSide.value:
-          return 1;
-        case isHighlightAreaActive.value:
-          return 0.7;
-        case isDestroyed.value:
-          return 0;
-        default:
-          return 1;
+      if (overDragSide.value) {
+        return 1;
       }
+      if (isHighlightAreaActive.value) {
+        return 0.7;
+      }
+      if (isDestroyed.value) {
+        return 0;
+      }
+      return 1;
     };
 
     const getExtraOffsetX = () => {
-      switch (true) {
-        case overDragSide.value === null || !!dockSide.value:
-          return 0;
-        case overDragSide.value === 'left':
-          return -edgeHandleLayout.value.width;
-        case overDragSide.value === 'right':
-          return edgeHandleLayout.value.width;
-        default:
-          return 0;
+      if (overDragSide.value === null || dockSide.value) {
+        return 0;
       }
+      if (overDragSide.value === 'left') {
+        return -edgeHandleLayout.value.width;
+      }
+      if (overDragSide.value === 'right') {
+        return edgeHandleLayout.value.width;
+      }
+      return 0;
     };
 
     const extraOverDragOffsetX = getExtraOffsetX();
@@ -218,6 +207,10 @@ export const PiPViewImpl = ({ children }: PropsWithChildren) => {
             animationsPresets.lazy
           ),
         },
+        // Intentionally two separate `scale` entries — RN composes
+        // transforms multiplicatively (matrix product), so the pinch
+        // spring and the state-driven timing animate independently.
+        // Do NOT merge them into a single entry.
         {
           scale: withSpring(scale.value, animationsPresets.softLanding),
         },
@@ -236,7 +229,6 @@ export const PiPViewImpl = ({ children }: PropsWithChildren) => {
   const destroyAreaStyle = useAnimatedStyle(() => {
     const active = isPanActive.value && !dockSide.value;
     return {
-      opacity: 1,
       backgroundColor: withTiming(
         isHighlightAreaActive.value
           ? destroyArea?.activeColor || 'rgba(255, 255, 255, 0.15)'
@@ -251,7 +243,10 @@ export const PiPViewImpl = ({ children }: PropsWithChildren) => {
     };
   });
 
-  const containerStyles = useAnimatedStyle(() => ({
+  // Kept separate from the size style below — the size updates every frame
+  // during a pinch, and re-evaluating withDelay/withSpring alongside it
+  // would restart the entry animation on each frame.
+  const containerOpacityStyle = useAnimatedStyle(() => ({
     opacity: withDelay(
       200,
       withSpring(
@@ -259,7 +254,12 @@ export const PiPViewImpl = ({ children }: PropsWithChildren) => {
         animationsPresets.responsiveSpring
       )
     ),
-    // Constrain the container to the PIP element size. Without explicit
+  }));
+
+  // Constrain the container to the PiP element size. Without explicit
+  // width/height the gesture detector's hit area would extend beyond the
+  // visible PiP (issue #4).
+  const containerSizeStyle = useAnimatedStyle(() => ({
     width: scaledElementLayout.value.width,
     height: scaledElementLayout.value.height,
   }));
@@ -272,7 +272,7 @@ export const PiPViewImpl = ({ children }: PropsWithChildren) => {
 
       {layout.width > 0 && layout.height > 0 && (
         <Animated.View
-          style={[containerStyles, styles.container]}
+          style={[containerOpacityStyle, containerSizeStyle, styles.container]}
           pointerEvents="box-none"
         >
           <GestureDetector gesture={gesture}>

--- a/src/components/RightEdgeHandle.tsx
+++ b/src/components/RightEdgeHandle.tsx
@@ -9,23 +9,15 @@ interface Props {
 }
 
 export const RightEdgeHandle = ({ onPress }: Props) => {
-  const { dockSide, overDragSide, edgeHandleLayout } = usePiPViewContext(
-    (state) => ({
-      overDragSide: state.overDragSide,
-      dockSide: state.dockSide,
-      edgeHandleLayout: state.edgeHandleLayout,
-    })
-  );
+  const dockSide = usePiPViewContext((state) => state.dockSide);
+  const overDragSide = usePiPViewContext((state) => state.overDragSide);
+  const edgeHandleLayout = usePiPViewContext((state) => state.edgeHandleLayout);
 
   const translateX = useDerivedValue(() => {
-    switch (true) {
-      case overDragSide.value === 'right':
-        return -edgeHandleLayout.value.width;
-      case dockSide.value === 'right':
-        return -edgeHandleLayout.value.width;
-      default:
-        return 0;
+    if (overDragSide.value === 'right' || dockSide.value === 'right') {
+      return -edgeHandleLayout.value.width;
     }
+    return 0;
   });
 
   const isVisible = useDerivedValue(

--- a/src/context/PiPView.provider.tsx
+++ b/src/context/PiPView.provider.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type PropsWithChildren } from 'react';
+import { type PropsWithChildren } from 'react';
 import { type LayoutRectangle } from 'react-native';
 import { type SharedValue } from 'react-native-reanimated';
 import { createContext, useContextSelector } from 'use-context-selector';
@@ -38,14 +38,14 @@ type PiPViewContextType =
 
 const PiPViewContext = createContext<PiPViewContextType>(null);
 
-interface Props extends NonNullable<PiPViewContextType> {}
+interface Props {
+  value: NonNullable<PiPViewContextType>;
+}
 
 export const PiPViewProvider = ({
   children,
-  ...props
+  value,
 }: PropsWithChildren<Props>) => {
-  const value = useMemo(() => props, [props]);
-
   return (
     <PiPViewContext.Provider value={value}>{children}</PiPViewContext.Provider>
   );

--- a/src/hooks/useDragHelpers.ts
+++ b/src/hooks/useDragHelpers.ts
@@ -48,14 +48,25 @@ export const useDragHelpers = () => {
     return y < midY ? edges.get().minY : edges.get().maxY;
   };
 
+  // Primitives keep the worklet closure stable when the consumer passes
+  // a new (but equal) `destroyArea` object on re-render — otherwise the
+  // pan gesture capturing this helper would be rebuilt on every render.
+  const destroyAreaX = destroyArea?.layout.x;
+  const destroyAreaY = destroyArea?.layout.y;
+  const destroyAreaWidth = destroyArea?.layout.width;
+  const destroyAreaHeight = destroyArea?.layout.height;
+
   const isWithinDestroyArea = (x: number, y: number) => {
     'worklet';
-    return isWithinDestroyAreaUtil(
-      x,
-      y,
-      scaledElementLayout.get(),
-      destroyArea?.layout
-    );
+    if (destroyAreaWidth == null || destroyAreaHeight == null) {
+      return false;
+    }
+    return isWithinDestroyAreaUtil(x, y, scaledElementLayout.get(), {
+      x: destroyAreaX,
+      y: destroyAreaY,
+      width: destroyAreaWidth,
+      height: destroyAreaHeight,
+    });
   };
 
   const handleHideTransition = (targetX: number, side: EdgeSide) => {

--- a/src/hooks/useDragHelpers.ts
+++ b/src/hooks/useDragHelpers.ts
@@ -1,25 +1,21 @@
-import { useCallback } from 'react';
 import { clamp, useDerivedValue } from 'react-native-reanimated';
+
 import { usePiPViewContext } from '../context/PiPView.provider';
+import { type EdgeSide } from '../models';
+import { isWithinDestroyArea as isWithinDestroyAreaUtil } from '../utils/destroyArea';
+
+const HIDDEN_EDGE_PADDING = 50;
 
 export const useDragHelpers = () => {
-  const {
-    _providedEdges,
-    scaledElementLayout,
-    hideable,
-    translationX,
-    overDragOffset,
-    dockSide,
-    destroyArea,
-  } = usePiPViewContext((state) => ({
-    _providedEdges: state.edges,
-    scaledElementLayout: state.scaledElementLayout,
-    translationX: state.translationX,
-    hideable: state.hideable,
-    overDragOffset: state.overDragOffset,
-    dockSide: state.dockSide,
-    destroyArea: state.destroyArea,
-  }));
+  const _providedEdges = usePiPViewContext((state) => state.edges);
+  const scaledElementLayout = usePiPViewContext(
+    (state) => state.scaledElementLayout
+  );
+  const hideable = usePiPViewContext((state) => state.hideable);
+  const translationX = usePiPViewContext((state) => state.translationX);
+  const overDragOffset = usePiPViewContext((state) => state.overDragOffset);
+  const dockSide = usePiPViewContext((state) => state.dockSide);
+  const destroyArea = usePiPViewContext((state) => state.destroyArea);
 
   const edges = useDerivedValue(
     () =>
@@ -31,105 +27,56 @@ export const useDragHelpers = () => {
       }
   );
 
-  const applyResistance = (offset: number, min: number, max: number) => {
+  const checkOverDrag = (x: number): [boolean, boolean] => {
     'worklet';
-    const resistanceFactor = 0.5;
-    if (offset < min) {
-      return min + (offset - min) * resistanceFactor;
-    } else if (offset > max) {
-      return max + (offset - max) * resistanceFactor;
-    } else {
-      return offset;
+
+    if (!hideable) {
+      return [false, false];
     }
+    const overDragLeftPosition = edges.get().minX - x;
+    const overDragRightPosition = x - edges.get().maxX;
+
+    const isOverDraggedLeft = overDragLeftPosition > overDragOffset.get();
+    const isOverDraggedRight = overDragRightPosition > overDragOffset.get();
+
+    return [isOverDraggedLeft, isOverDraggedRight];
   };
 
-  const checkOverDrag = useCallback(
-    (x: number) => {
-      'worklet';
+  const findNearestYEdge = (y: number) => {
+    'worklet';
+    const midY = (edges.get().minY + edges.get().maxY) / 2;
+    return y < midY ? edges.get().minY : edges.get().maxY;
+  };
 
-      if (!hideable) {
-        return [false, false];
-      }
-      const overDragLeftPosition = edges.value.minX - x;
-      const overDragRightPosition = x - edges.value.maxX;
+  const isWithinDestroyArea = (x: number, y: number) => {
+    'worklet';
+    return isWithinDestroyAreaUtil(
+      x,
+      y,
+      scaledElementLayout.get(),
+      destroyArea?.layout
+    );
+  };
 
-      const isOverDraggedLeft = overDragLeftPosition > overDragOffset.value;
-      const isOverDraggedRight = overDragRightPosition > overDragOffset.value;
-
-      return [isOverDraggedLeft, isOverDraggedRight];
-    },
-    [edges, hideable, overDragOffset]
-  );
-
-  const findNearestYEdge = useCallback(
-    (y: number) => {
-      'worklet';
-      const midY = (edges.value.minY + edges.value.maxY) / 2;
-      return y < midY ? edges.value.minY : edges.value.maxY;
-    },
-    [edges]
-  );
-
-  const isWithinHighlightArea = useCallback(
-    (x: number, y: number) => {
-      'worklet';
-      if (destroyArea?.layout) {
-        const draggableLeft = x;
-        const draggableRight = x + scaledElementLayout.value.width;
-        const draggableTop = y;
-        const draggableBottom = y + scaledElementLayout.value.height;
-
-        // Coordinates and dimensions of the highlighted area
-        const highlightedLeft = destroyArea.layout.x ?? 0;
-        const highlightedRight =
-          (destroyArea.layout.x ?? 0) + destroyArea.layout.width;
-        const highlightedTop = destroyArea.layout.y ?? 0;
-        const highlightedBottom =
-          (destroyArea.layout.y ?? 0) + destroyArea.layout.height;
-
-        // Check for overlap
-        const isOverlapping =
-          draggableLeft < highlightedRight &&
-          draggableRight > highlightedLeft &&
-          draggableTop < highlightedBottom &&
-          draggableBottom > highlightedTop;
-
-        return isOverlapping;
-      }
-      return false;
-    },
-    [
-      destroyArea?.layout,
-      scaledElementLayout.value.height,
-      scaledElementLayout.value.width,
-    ]
-  );
-
-  const handleHideTansition = useCallback(
-    (targetX: number, side: 'left' | 'right') => {
-      'worklet';
-      translationX.value = clamp(
+  const handleHideTransition = (targetX: number, side: EdgeSide) => {
+    'worklet';
+    translationX.set(
+      clamp(
         targetX,
-        edges.value.minX - scaledElementLayout.value.width - 50,
-        edges.value.maxX + scaledElementLayout.value.width + 50
-      );
+        edges.get().minX -
+          scaledElementLayout.get().width -
+          HIDDEN_EDGE_PADDING,
+        edges.get().maxX + scaledElementLayout.get().width + HIDDEN_EDGE_PADDING
+      )
+    );
 
-      dockSide.value = side;
-    },
-    [
-      dockSide,
-      edges.value.maxX,
-      edges.value.minX,
-      scaledElementLayout.value.width,
-      translationX,
-    ]
-  );
+    dockSide.set(side);
+  };
 
   return {
-    handleHideTansition,
-    isWithinHighlightArea,
+    handleHideTransition,
+    isWithinDestroyArea,
     findNearestYEdge,
     checkOverDrag,
-    applyResistance,
   };
 };

--- a/src/hooks/useInitialPosition.ts
+++ b/src/hooks/useInitialPosition.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import {
   useAnimatedReaction,
   useDerivedValue,
@@ -25,63 +24,69 @@ export const useInitialPosition = ({
   isInitialized,
   layout,
 }: Options) => {
+  // Primitives keep the worklet closures stable across consumer re-renders
+  // that pass a new (but equal) `layout` object.
+  const {
+    x: layoutX,
+    y: layoutY,
+    horizontalOffset: layoutHorizontalOffset,
+  } = layout;
+
   const isNumberValue = (value: any | undefined): value is number => {
     'worklet';
     return typeof value === 'number' && !Number.isNaN(value);
   };
 
-  const resolveXPosition = useCallback(
-    (position?: number | 'left' | 'right' | 'center') => {
-      'worklet';
-      if (isNumberValue(position)) {
-        const positionWithinContainer =
-          position + (layout.x || 0) + (layout.horizontalOffset ?? 0);
-        return positionWithinContainer;
-      }
+  const resolveXPosition = (
+    position?: number | 'left' | 'right' | 'center'
+  ) => {
+    'worklet';
+    if (isNumberValue(position)) {
+      const positionWithinContainer =
+        position + (layoutX || 0) + (layoutHorizontalOffset ?? 0);
+      return positionWithinContainer;
+    }
 
-      if (!edges.value) {
+    if (!edges.value) {
+      return 0;
+    }
+
+    switch (position) {
+      case 'left':
+        return edges.value.minX;
+      case 'right':
+        return edges.value.maxX;
+      case 'center':
+        return edges.value.minX + (edges.value.maxX - edges.value.minX) / 2;
+      default:
         return 0;
-      }
+    }
+  };
 
-      switch (position) {
-        case 'left':
-          return edges.value.minX;
-        case 'right':
-          return edges.value.maxX;
-        case 'center':
-          return (edges.value.maxX - edges.value.minX) / 2;
-        default:
-          return 0;
-      }
-    },
-    [edges.value, layout.horizontalOffset, layout.x]
-  );
+  const resolveYPosition = (
+    position?: number | 'top' | 'bottom' | 'center'
+  ) => {
+    'worklet';
+    if (isNumberValue(position)) {
+      const positionWithinContainer = position + (layoutY || 0);
+      return positionWithinContainer;
+    }
 
-  const resolveYPosition = useCallback(
-    (position?: number | 'top' | 'bottom' | 'center') => {
-      'worklet';
-      if (isNumberValue(position)) {
-        const positionWithinContainer = position + (layout.y || 0);
-        return positionWithinContainer;
-      }
+    if (!edges.value) {
+      return 0;
+    }
 
-      if (!edges.value) {
+    switch (position) {
+      case 'top':
+        return edges.value.minY;
+      case 'bottom':
+        return edges.value.maxY;
+      case 'center':
+        return edges.value.minY + (edges.value.maxY - edges.value.minY) / 2;
+      default:
         return 0;
-      }
-
-      switch (position) {
-        case 'top':
-          return edges.value.minY;
-        case 'bottom':
-          return edges.value.maxY;
-        case 'center':
-          return (edges.value.maxY - edges.value.minY) / 2;
-        default:
-          return 0;
-      }
-    },
-    [edges.value, layout.y]
-  );
+    }
+  };
 
   const initials = useDerivedValue(() => {
     if (!isInitialized.value || !edges.value) {
@@ -106,10 +111,10 @@ export const useInitialPosition = ({
     }),
     ({ initialized, initialValues }, prev) => {
       if (initialValues && initialized && prev?.initialized !== initialized) {
-        translationX.value = initialValues.x;
-        translationY.value = initialValues.y;
-        prevTranslationX.value = initialValues.x;
-        prevTranslationY.value = initialValues.y;
+        translationX.set(initialValues.x);
+        translationY.set(initialValues.y);
+        prevTranslationX.set(initialValues.x);
+        prevTranslationY.set(initialValues.y);
       }
     }
   );

--- a/src/hooks/usePanGesture.ts
+++ b/src/hooks/usePanGesture.ts
@@ -1,17 +1,20 @@
-import { useCallback, useMemo } from 'react';
 import {
   Gesture,
   type GestureStateChangeEvent,
   type PanGestureHandlerEventPayload,
   type PanGesture,
 } from 'react-native-gesture-handler';
-import { clamp, runOnJS, useDerivedValue } from 'react-native-reanimated';
+import { clamp, useDerivedValue } from 'react-native-reanimated';
+import { scheduleOnRN } from 'react-native-worklets';
 
 import { useDragHelpers } from './useDragHelpers';
 import { usePiPViewContext } from '../context/PiPView.provider';
+import { applyResistance } from '../utils/gestures';
+import { getCurrentHorizontalSide } from '../utils/snapping';
 
 const VELOCITY_Y_MULTIPLIER = 0.1;
 const VELOCITY_X_MULTIPLIER = 0.05;
+const VELOCITY_THRESHOLD = 1700;
 
 export const usePanGesture = (): {
   pan: PanGesture;
@@ -19,39 +22,28 @@ export const usePanGesture = (): {
     event?: GestureStateChangeEvent<PanGestureHandlerEventPayload>
   ) => void;
 } => {
-  const {
-    _providedEdges,
-    dockSide,
-    scaledElementLayout,
-    hideable,
-    snapToEdges,
-    translationX,
-    translationY,
-    overDragSide,
-    isPanActive,
-    isHighlightAreaActive,
-    layout,
-    disabled,
-    onDestroy,
-    prevTranslationX,
-    prevTranslationY,
-  } = usePiPViewContext((state) => ({
-    snapToEdges: state.snapToEdges,
-    _providedEdges: state.edges,
-    dockSide: state.dockSide,
-    scaledElementLayout: state.scaledElementLayout,
-    translationX: state.translationX,
-    hideable: state.hideable,
-    translationY: state.translationY,
-    overDragSide: state.overDragSide,
-    isPanActive: state.isPanActive,
-    isHighlightAreaActive: state.isHighlightAreaActive,
-    layout: state.layout,
-    disabled: state.disabled,
-    onDestroy: state.onDestroy,
-    prevTranslationX: state.prevTranslationX,
-    prevTranslationY: state.prevTranslationY,
-  }));
+  const snapToEdges = usePiPViewContext((state) => state.snapToEdges);
+  const _providedEdges = usePiPViewContext((state) => state.edges);
+  const dockSide = usePiPViewContext((state) => state.dockSide);
+  const scaledElementLayout = usePiPViewContext(
+    (state) => state.scaledElementLayout
+  );
+  const translationX = usePiPViewContext((state) => state.translationX);
+  const hideable = usePiPViewContext((state) => state.hideable);
+  const translationY = usePiPViewContext((state) => state.translationY);
+  const overDragSide = usePiPViewContext((state) => state.overDragSide);
+  const isPanActive = usePiPViewContext((state) => state.isPanActive);
+  const isHighlightAreaActive = usePiPViewContext(
+    (state) => state.isHighlightAreaActive
+  );
+  const layout = usePiPViewContext((state) => state.layout);
+  const disabled = usePiPViewContext((state) => state.disabled);
+  const onDestroy = usePiPViewContext((state) => state.onDestroy);
+  const handleDestroy = usePiPViewContext((state) => state.handleDestroy);
+  const isDestroyed = usePiPViewContext((state) => state.isDestroyed);
+  const prevTranslationX = usePiPViewContext((state) => state.prevTranslationX);
+  const prevTranslationY = usePiPViewContext((state) => state.prevTranslationY);
+
   const edges = useDerivedValue(
     () =>
       _providedEdges.value || {
@@ -63,221 +55,185 @@ export const usePanGesture = (): {
   );
 
   const {
-    applyResistance,
     checkOverDrag,
     findNearestYEdge,
-    handleHideTansition,
-    isWithinHighlightArea,
+    handleHideTransition,
+    isWithinDestroyArea,
   } = useDragHelpers();
+
+  // Primitives keep the worklet closures stable when the consumer passes
+  // a new (but equal) `layout` object on re-render — otherwise the pan
+  // gesture would be rebuilt and re-attached on every render.
+  const { width: layoutWidth, horizontalOffset: layoutHorizontalOffset } =
+    layout;
 
   const hiddenLeftXValue = useDerivedValue(
     () =>
       edges.value.minX -
       scaledElementLayout.value.width -
-      (layout.horizontalOffset ?? 0) * 1
+      (layoutHorizontalOffset ?? 0)
   );
 
   const hiddenRightXValue = useDerivedValue(
     () =>
       edges.value.maxX +
       scaledElementLayout.value.width +
-      (layout.horizontalOffset ?? 0) * 1
+      (layoutHorizontalOffset ?? 0)
   );
 
-  const handlePanEnd = useCallback(
-    (event?: GestureStateChangeEvent<PanGestureHandlerEventPayload>) => {
-      'worklet';
+  const handlePanEnd = (
+    event?: GestureStateChangeEvent<PanGestureHandlerEventPayload>
+  ) => {
+    'worklet';
 
-      const velocityX = event?.velocityX || 0;
-      const velocityY = event?.velocityY || 0;
-      const velocityThreshold = 1700;
+    const velocityX = event?.velocityX || 0;
+    const velocityY = event?.velocityY || 0;
 
-      const [isOverDraggedLeft, isOverDraggedRight] = checkOverDrag(
-        translationX.value
-      );
-      let dockSideTmp = dockSide.value;
+    const [isOverDraggedLeft, isOverDraggedRight] = checkOverDrag(
+      translationX.get()
+    );
+    let dockSideTmp = dockSide.get();
 
-      if (isOverDraggedLeft) {
-        translationX.set(hiddenLeftXValue.value);
-        dockSide.set('left');
-        dockSideTmp = 'left';
+    if (isOverDraggedLeft) {
+      translationX.set(hiddenLeftXValue.get());
+      dockSide.set('left');
+      dockSideTmp = 'left';
 
-        isPanActive.set(false);
-        isHighlightAreaActive.set(false);
-        overDragSide.set(null);
-
-        if (snapToEdges) {
-          translationY.set(translationY.value);
-        }
-
-        return;
-      } else if (isOverDraggedRight) {
-        translationX.set(hiddenRightXValue.value);
-        dockSide.set('right');
-        dockSideTmp = 'right';
-
-        isPanActive.set(false);
-        isHighlightAreaActive.set(false);
-        overDragSide.set(null);
-
-        if (snapToEdges) {
-          translationY.set(translationY.value);
-        }
-
-        return;
-      }
-
-      const targetYWithVelocity =
-        translationY.value + velocityY * VELOCITY_Y_MULTIPLIER;
-      const clampedY = clamp(
-        targetYWithVelocity,
-        edges.value.minY,
-        edges.value.maxY
-      );
-
-      const targetXWithVelocity =
-        translationX.value + velocityX * VELOCITY_X_MULTIPLIER;
-
-      const snapToLeft =
-        targetXWithVelocity <
-        (layout.width - scaledElementLayout.value.width) / 2;
-
-      let targetX = 0;
-
-      const shouldHideLeft =
-        targetXWithVelocity < edges.value.minX &&
-        velocityX < -velocityThreshold &&
-        hideable;
-      const shouldHideRight =
-        targetXWithVelocity > edges.value.maxX &&
-        velocityX > velocityThreshold &&
-        hideable;
-
-      if (shouldHideLeft) {
-        targetX = hiddenLeftXValue.value;
-
-        handleHideTansition(targetX, 'left');
-      } else if (shouldHideRight) {
-        targetX = hiddenRightXValue.value;
-
-        handleHideTansition(targetX, 'right');
-      } else {
-        targetX = snapToLeft ? edges.value.minX : edges.value.maxX;
-        dockSide.set(null);
-        dockSideTmp = null;
-      }
-
-      if (!dockSideTmp && !shouldHideLeft && !shouldHideRight) {
-        translationX.set(targetX);
-      }
-      if (snapToEdges && !dockSideTmp) {
-        translationY.set(findNearestYEdge(clampedY));
-      } else {
-        translationY.set(clampedY);
-      }
       isPanActive.set(false);
       isHighlightAreaActive.set(false);
       overDragSide.set(null);
-    },
-    [
-      checkOverDrag,
-      translationX,
-      translationY,
-      edges.value.minY,
-      edges.value.maxY,
-      edges.value.minX,
-      edges.value.maxX,
-      layout.width,
-      scaledElementLayout.value.width,
-      hideable,
-      dockSide,
-      snapToEdges,
-      isPanActive,
-      isHighlightAreaActive,
-      overDragSide,
-      hiddenLeftXValue.value,
-      hiddenRightXValue.value,
-      handleHideTansition,
-      findNearestYEdge,
-    ]
-  );
 
-  const pan = useMemo(() => {
-    return Gesture.Pan()
-      .onStart(() => {
-        'worklet';
-        if (disabled) {
-          return;
-        }
-        prevTranslationX.set(translationX.value);
-        prevTranslationY.set(translationY.value);
-        isPanActive.set(true);
-      })
-      .onUpdate((e) => {
-        'worklet';
-        if (disabled) {
-          return;
-        }
+      return;
+    } else if (isOverDraggedRight) {
+      translationX.set(hiddenRightXValue.get());
+      dockSide.set('right');
+      dockSideTmp = 'right';
 
-        const newTranslationY = prevTranslationY.value + e.translationY;
+      isPanActive.set(false);
+      isHighlightAreaActive.set(false);
+      overDragSide.set(null);
 
-        translationY.set(
-          applyResistance(newTranslationY, edges.value.minY, edges.value.maxY)
-        );
+      return;
+    }
 
-        const newTranslationX = prevTranslationX.value + e.translationX;
+    const targetYWithVelocity =
+      translationY.get() + velocityY * VELOCITY_Y_MULTIPLIER;
+    const clampedY = clamp(
+      targetYWithVelocity,
+      edges.get().minY,
+      edges.get().maxY
+    );
 
-        if (isWithinHighlightArea(newTranslationX, newTranslationY)) {
-          isHighlightAreaActive.set(true);
-        } else {
-          isHighlightAreaActive.set(false);
-        }
+    const targetXWithVelocity =
+      translationX.get() + velocityX * VELOCITY_X_MULTIPLIER;
 
-        const [isOverDraggedLeft, isOverDraggedRight] =
-          checkOverDrag(newTranslationX);
+    const snapToLeft =
+      getCurrentHorizontalSide(
+        targetXWithVelocity,
+        layoutWidth,
+        scaledElementLayout.get().width
+      ) === 'left';
 
-        if (isOverDraggedLeft) {
-          overDragSide.set('left');
-        } else if (isOverDraggedRight) {
-          overDragSide.set('right');
-        } else {
-          overDragSide.set(null);
-        }
+    let targetX = 0;
 
-        translationX.set(newTranslationX);
-      })
-      .onEnd((event) => {
-        'worklet';
-        if (disabled) {
-          return;
-        }
+    const shouldHideLeft =
+      targetXWithVelocity < edges.get().minX &&
+      velocityX < -VELOCITY_THRESHOLD &&
+      hideable;
+    const shouldHideRight =
+      targetXWithVelocity > edges.get().maxX &&
+      velocityX > VELOCITY_THRESHOLD &&
+      hideable;
 
-        if (
-          onDestroy &&
-          isWithinHighlightArea(translationX.value, translationY.value)
-        ) {
-          runOnJS(onDestroy)();
-          return;
-        }
-        handlePanEnd(event);
-      });
-  }, [
-    applyResistance,
-    checkOverDrag,
-    disabled,
-    edges.value.maxY,
-    edges.value.minY,
-    handlePanEnd,
-    isPanActive,
-    isHighlightAreaActive,
-    isWithinHighlightArea,
-    onDestroy,
-    overDragSide,
-    prevTranslationX,
-    prevTranslationY,
-    translationX,
-    translationY,
-  ]);
+    if (shouldHideLeft) {
+      targetX = hiddenLeftXValue.get();
+
+      handleHideTransition(targetX, 'left');
+    } else if (shouldHideRight) {
+      targetX = hiddenRightXValue.get();
+
+      handleHideTransition(targetX, 'right');
+    } else {
+      targetX = snapToLeft ? edges.get().minX : edges.get().maxX;
+      dockSide.set(null);
+      dockSideTmp = null;
+    }
+
+    if (!dockSideTmp && !shouldHideLeft && !shouldHideRight) {
+      translationX.set(targetX);
+    }
+    if (snapToEdges && !dockSideTmp) {
+      translationY.set(findNearestYEdge(clampedY));
+    } else {
+      translationY.set(clampedY);
+    }
+    isPanActive.set(false);
+    isHighlightAreaActive.set(false);
+    overDragSide.set(null);
+  };
+
+  const pan = Gesture.Pan()
+    .enabled(!disabled)
+    .onStart(() => {
+      'worklet';
+      prevTranslationX.set(translationX.get());
+      prevTranslationY.set(translationY.get());
+      isPanActive.set(true);
+    })
+    .onUpdate((e) => {
+      'worklet';
+      const newTranslationY = prevTranslationY.get() + e.translationY;
+
+      translationY.set(
+        applyResistance(newTranslationY, edges.get().minY, edges.get().maxY)
+      );
+
+      const rawTranslationX = prevTranslationX.get() + e.translationX;
+      // When the view cannot be hidden there is no overdrag, so pushing
+      // past the horizontal edges should feel resistant, same as the Y axis.
+      const newTranslationX = hideable
+        ? rawTranslationX
+        : applyResistance(rawTranslationX, edges.get().minX, edges.get().maxX);
+
+      isHighlightAreaActive.set(
+        isWithinDestroyArea(newTranslationX, newTranslationY)
+      );
+
+      const [isOverDraggedLeft, isOverDraggedRight] =
+        checkOverDrag(newTranslationX);
+
+      if (isOverDraggedLeft) {
+        overDragSide.set('left');
+      } else if (isOverDraggedRight) {
+        overDragSide.set('right');
+      } else {
+        overDragSide.set(null);
+      }
+
+      translationX.set(newTranslationX);
+    })
+    .onEnd((event) => {
+      'worklet';
+      if (
+        onDestroy &&
+        isWithinDestroyArea(translationX.get(), translationY.get())
+      ) {
+        // Set on the UI thread right away — scheduleOnRN lands a frame or
+        // two later and the destroy animation would briefly flicker.
+        isDestroyed.set(true);
+        scheduleOnRN(handleDestroy);
+        return;
+      }
+      handlePanEnd(event);
+    })
+    .onFinalize(() => {
+      'worklet';
+      // Cleanup that survives gesture cancellation (e.g. `disabled`
+      // flipping mid-gesture) — onEnd is not guaranteed to run then.
+      isPanActive.set(false);
+      isHighlightAreaActive.set(false);
+      overDragSide.set(null);
+    });
 
   return { pan, handlePanEnd };
 };

--- a/src/hooks/usePinchGesture.ts
+++ b/src/hooks/usePinchGesture.ts
@@ -1,7 +1,16 @@
-import { useMemo } from 'react';
 import { Gesture, type PinchGesture } from 'react-native-gesture-handler';
 import { clamp, useSharedValue } from 'react-native-reanimated';
+
 import { usePiPViewContext } from '../context/PiPView.provider';
+
+const SCALE_RESISTANCE_FACTOR = 0.4;
+const SCALE_MIN = 0.5;
+const SCALE_MAX = 1.5;
+const SCALE_SNAP_SMALL = 0.7;
+const SCALE_SNAP_NORMAL = 1;
+const SCALE_SNAP_LARGE = 1.3;
+const SCALE_SMALL_THRESHOLD = 0.85;
+const SCALE_NORMAL_THRESHOLD = 1.15;
 
 interface Options {
   onEnd: () => void;
@@ -13,37 +22,43 @@ export const usePinchGesture = ({
   pinchGesture: PinchGesture;
 } => {
   const scale = usePiPViewContext((state) => state.scale);
+  const disabled = usePiPViewContext((state) => state.disabled);
+  const isPanActive = usePiPViewContext((state) => state.isPanActive);
   const pinchScaleOffset = useSharedValue(1);
-  const SCALE_RESISTANCE_FACTOR = 0.4;
 
-  const pinchGesture = useMemo(
-    () =>
-      Gesture.Pinch()
-        .onStart(() => {
-          'worklet';
-          pinchScaleOffset.value = scale.value;
-        })
-        .onUpdate((event) => {
-          'worklet';
-          const pinchDelta = (event.scale - 1) * SCALE_RESISTANCE_FACTOR;
-          const value = pinchScaleOffset.value * (1 + pinchDelta);
-          scale.value = clamp(value, 0.5, 1.5);
-        })
-        .onEnd(() => {
-          'worklet';
-          let target = 1;
-          if (scale.value < 0.85) {
-            target = 0.7;
-          } else if (scale.value < 1.15) {
-            target = 1;
-          } else {
-            target = 1.3;
-          }
-          scale.value = target;
-          onEnd();
-        }),
-    [onEnd, pinchScaleOffset, scale]
-  );
+  const pinchGesture = Gesture.Pinch()
+    .enabled(!disabled)
+    .onStart(() => {
+      'worklet';
+      pinchScaleOffset.set(scale.get());
+    })
+    .onUpdate((event) => {
+      'worklet';
+      const pinchDelta = (event.scale - 1) * SCALE_RESISTANCE_FACTOR;
+      const value = pinchScaleOffset.get() * (1 + pinchDelta);
+      scale.set(clamp(value, SCALE_MIN, SCALE_MAX));
+    })
+    .onFinalize((_event, success) => {
+      'worklet';
+      // Snap the scale even when the gesture gets cancelled, so it
+      // never settles on an intermediate value.
+      let target = SCALE_SNAP_NORMAL;
+      if (scale.get() < SCALE_SMALL_THRESHOLD) {
+        target = SCALE_SNAP_SMALL;
+      } else if (scale.get() < SCALE_NORMAL_THRESHOLD) {
+        target = SCALE_SNAP_NORMAL;
+      } else {
+        target = SCALE_SNAP_LARGE;
+      }
+      scale.set(target);
+
+      // Re-snap the position only when the pinch actually ended and
+      // the pan gesture is not in control anymore — otherwise lifting
+      // one finger mid-drag would yank the view to an edge.
+      if (success && !isPanActive.get()) {
+        onEnd();
+      }
+    });
 
   return { pinchGesture };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,9 @@
+export { PiPView } from './components/PiPView';
+export { PiPViewBlurOverlay } from './components/PiPViewBlurOverlay';
+export {
+  type ContainerLayoutRectangle,
+  type DestroyArea,
+  type PiPViewInitialPosition,
+  type PiPViewProps,
+  type ScreenLayoutDimensions,
+} from './models';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,0 @@
-export { PiPView } from './components/PiPView';
-export { PiPViewBlurOverlay } from './components/PiPViewBlurOverlay';
-export { type PiPViewInitialPosition } from './models';

--- a/src/utils/destroyArea.ts
+++ b/src/utils/destroyArea.ts
@@ -1,0 +1,31 @@
+import { type ContainerLayoutRectangle, type Dimensions } from '../models';
+
+export const isWithinDestroyArea = (
+  x: number,
+  y: number,
+  elementSize: Dimensions,
+  destroyAreaLayout?: ContainerLayoutRectangle
+): boolean => {
+  'worklet';
+
+  if (!destroyAreaLayout) {
+    return false;
+  }
+
+  const draggableLeft = x;
+  const draggableRight = x + elementSize.width;
+  const draggableTop = y;
+  const draggableBottom = y + elementSize.height;
+
+  const destroyLeft = destroyAreaLayout.x ?? 0;
+  const destroyRight = destroyLeft + destroyAreaLayout.width;
+  const destroyTop = destroyAreaLayout.y ?? 0;
+  const destroyBottom = destroyTop + destroyAreaLayout.height;
+
+  return (
+    draggableLeft < destroyRight &&
+    draggableRight > destroyLeft &&
+    draggableTop < destroyBottom &&
+    draggableBottom > destroyTop
+  );
+};

--- a/src/utils/gestures.ts
+++ b/src/utils/gestures.ts
@@ -1,0 +1,14 @@
+export const applyResistance = (
+  offset: number,
+  min: number,
+  max: number,
+  resistanceFactor = 0.5
+): number => {
+  'worklet';
+  if (offset < min) {
+    return min + (offset - min) * resistanceFactor;
+  } else if (offset > max) {
+    return max + (offset - max) * resistanceFactor;
+  }
+  return offset;
+};

--- a/src/utils/snapping.ts
+++ b/src/utils/snapping.ts
@@ -1,11 +1,16 @@
 import { type SharedValue } from 'react-native-reanimated';
 
-import { type Dimensions, type ScreenLayoutDimensions } from './models';
+import {
+  type Dimensions,
+  type EdgeSide,
+  type Edges,
+  type ScreenLayoutDimensions,
+} from '../models';
 
 export const getEdges = (
   currentContainerLayout: ScreenLayoutDimensions,
   currentScaledElementLayout: SharedValue<Dimensions>
-) => {
+): Edges => {
   'worklet';
 
   return {
@@ -23,4 +28,13 @@ export const getEdges = (
       currentScaledElementLayout.value.height -
       (currentContainerLayout.horizontalOffset ?? 0),
   };
+};
+
+export const getCurrentHorizontalSide = (
+  x: number,
+  containerWidth: number,
+  elementWidth: number
+): EdgeSide => {
+  'worklet';
+  return x < (containerWidth - elementWidth) / 2 ? 'left' : 'right';
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11576,6 +11576,7 @@ __metadata:
     "@release-it/conventional-changelog": ^11.0.1
     "@types/jest": ^29.5.14
     "@types/react": 19.2.17
+    babel-plugin-react-compiler: ^1.0.0
     commitlint: ^21.0.2
     del-cli: ^7.0.0
     eslint: ^9.39.4


### PR DESCRIPTION
Supersedes #2 — reimplements its ideas on top of current main (the original branch was based on v0.3.7 and would reintroduce the `horizontalOffet` typo and revert the #4 fix), corrected by an in-depth review against current Reanimated 4 / Gesture Handler 2 / React 19 practices.

## Architecture

- Split `utils.ts` into `utils/snapping.ts`, `utils/gestures.ts`, `utils/destroyArea.ts` (pure worklets, constants passed as parameters)
- Stable context: explicit `contextValue` (no prop spreading), provider takes a single `value` prop, all consumers use single-field selectors — eliminates cascading re-renders from `use-context-selector`
- Public prop types (`PiPViewProps`, `DestroyArea`, `ScreenLayoutDimensions`, `ContainerLayoutRectangle`) exported from the entry point (now `index.ts`)

## React Compiler

- `babel-plugin-react-compiler` with `panicThreshold: 'all_errors'` (build fails if any component is skipped), bob `commonjs` target with `configFile: true`
- All manual memoization (`useMemo`/`useCallback`) removed — every component and hook verified compiled (`react/compiler-runtime` present in all `lib/commonjs` outputs)
- Notable constraints encountered: `switch (true)` is unsupported, shared values must be written via `.set()` instead of `.value =`, and `eslint-disable` comments for React rules hard-fail the build

## Behavior fixes

- **Destroy animation**: the `isDestroyed` path was dead — pan end now schedules `handleDestroy` (and sets `isDestroyed` on the UI thread), so the shrink-to-zero animation actually plays before `onDestroy`
- **`disabled`**: pan and pinch use `.enabled(!disabled)` — a disabled PiP no longer steals touches from its children, and pinch no longer scales/re-snaps a disabled PiP; `onPress` still works (documented)
- **Tap**: `.onEnd(success)` instead of `.onTouchesUp` — `onPress` fires exactly once, no double-fire on multi-touch
- **Docked handle presses**: the tap gesture wins the race against the edge handle's Touchable and used to swallow the press — it now performs the expand itself (with a guard against double invocation)
- **Pinch + pan**: scale snap moved to `.onFinalize` (also runs on cancel); position re-snap only when the pan is not in control — lifting one finger mid-drag no longer yanks the view
- **Layout identity**: worklet closures capture `layout` as primitives — consumer re-renders with inline `layout` objects no longer re-register reactions (previously the PiP snapped to the edge on unrelated state changes, e.g. toggling `disabled`)
- **X-axis resistance** when `hideable={false}` (no overdrag exists, so pushing past side edges now resists like the Y axis)
- **`initialPosition: 'center'`** now accounts for `minX`/`minY`
- `runOnJS` (deprecated) replaced with `scheduleOnRN` from `react-native-worklets`

## Example app

Six screens covering every prop combination (basic, hideable + blur overlay, custom handles, destroy area, disabled with inner interactive content, initial-position matrix with `snapToEdges={false}`), plus a dashed indicator visualizing the draggable area.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test`, `yarn prepare` (bob, with the compiler enforced via `panicThreshold`) all pass. Manually tested in the example app on the iOS simulator (drag/snap/resistance, pinch, dock + handle taps, destroy drop, disabled toggling, initial positions).

No public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)